### PR TITLE
Add fallback search for script containers

### DIFF
--- a/whitelist.js
+++ b/whitelist.js
@@ -44,9 +44,19 @@ function restoreOriginalContainers() {
             }
         } else if (wid.startsWith('JSR::')) {
             const scriptId = wid.substring(5);
-            const container = document.getElementById(`script_container_${scriptId}`);
+            let container = document.getElementById(`script_container_${scriptId}`);
+            if (!container) {
+                const allContainers = document.querySelectorAll('#qr--bar .qr--buttons');
+                allContainers.forEach(c => {
+                    if (!container && c.querySelector(`button[data-script-id="${scriptId}"]`)) {
+                        container = c;
+                    }
+                });
+            }
             if (container) {
                 container.classList.add('qrq-whitelisted-original');
+            } else {
+                console.warn(`QRQ whitelist: container for script_id ${scriptId} not found`);
             }
         }
     });


### PR DESCRIPTION
## Summary
- improve `restoreOriginalContainers` to search `#qr--bar .qr--buttons` when a script container ID is missing
- warn in console if no container is found

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6841a82f62ac8327828d05c49da4c153