### PR TITLE
Update whitelist selectors for nested buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,11 +1,11 @@
 /* 新规则：插件启用时，隐藏 #qr--bar 内的原始触发器和【不属于输入助手的】按钮容器 */
 /* 同时排除 #input_helper_toolbar（插件按钮） 和 #custom_buttons_container（脚本按钮） */
 body.qra-enabled #qr--bar > #qr--popoutTrigger,
-body.qra-enabled #qr--bar > .qr--buttons:not(#input_helper_toolbar):not(#custom_buttons_container) {
+body.qra-enabled #qr--bar .qr--buttons:not(#input_helper_toolbar):not(#custom_buttons_container) {
     display: none !important;
 }
 
-body.qra-enabled #qr--bar > .qr--buttons.qrq-whitelisted-original {
+body.qra-enabled #qr--bar .qr--buttons.qrq-whitelisted-original {
     display: flex !important;
 }
 

--- a/whitelist.js
+++ b/whitelist.js
@@ -3,7 +3,7 @@ import { sharedState } from './state.js';
 
 function resetOriginalContainers() {
     const containers = document.querySelectorAll(
-        '#qr--bar > .qr--buttons:not(#input_helper_toolbar):not(#custom_buttons_container)'
+        '#qr--bar .qr--buttons:not(#input_helper_toolbar):not(#custom_buttons_container)'
     );
     containers.forEach(c => c.classList.remove('qrq-whitelisted-original'));
 }


### PR DESCRIPTION
## Summary
- broaden `.qrq-whitelisted-original` selectors to match any descendant of `#qr--bar`
- update `resetOriginalContainers` to query descendant `.qr--buttons`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841a82e12b88327aadf5ff76ca7e337